### PR TITLE
Fix for Distributed use of WrappedRNG

### DIFF
--- a/src/RNGTest.jl
+++ b/src/RNGTest.jl
@@ -33,7 +33,7 @@ module RNGTest
         rng::RNG
         cache::Vector{T}
         fillarray::Bool
-        vals::Vector{UInt32}
+        vals::Union{Vector{UInt32}, Base.ReinterpretArray{UInt32, 1, T, Vector{T}, false}}
         idx::Int
     end
 
@@ -45,7 +45,7 @@ module RNGTest
         end
         cache = Vector{T}(undef, cache_size)
         fillcache(WrappedRNG{T, RNG}(rng, cache, fillarray,
-            unsafe_wrap(Array, convert(Ptr{UInt32}, pointer(cache)), sizeof(cache)÷sizeof(UInt32)),
+            reinterpret(UInt32, cache),
             0)) # 0 is a dummy value, which will be set correctly by fillcache
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -160,3 +160,14 @@ end
     RNGTest.smallcrushTestU01(rng)
     @test all(t -> t > pval, mapreduce(s -> [s...], vcat, RNGTest.smallcrushJulia(rng)))
 end
+
+@testset "Distributed smallcrushJulia" begin
+    pids = addprocs()
+    @everywhere using RNGTest
+    for T in (UInt32, UInt64, Float64)
+        rng = RNGTest.wrap(Xoshiro(), T)
+        results = RNGTest.smallcrushJulia(rng)
+        @test all(ps -> all(>(pval), ps), results)
+    end
+    rmprocs(pids)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,7 +166,11 @@ end
     pids = addprocs()
     @everywhere using RNGTest
     for T in (UInt32, UInt64, Float64)
-        rng = RNGTest.wrap(Xoshiro(), T)
+        if isdefined(Random, :Xoshiro)
+            rng = RNGTest.wrap(Xoshiro(), T)
+        else 
+            rng = RNGTest.wrap(MersenneTwister(), T)
+        end
         results = RNGTest.smallcrushJulia(rng)
         @test all(ps -> all(>(pval), ps), results)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using RNGTest
 using Random
+using Distributed
 
 f = rand
 pval = 0.001


### PR DESCRIPTION
Issue #30

Use `reinterpret` instead of `unsafe_wrap` when initializing `vals` field of `WrappedRNG`
I think `unsafe_wrap` uses pointers which become invalid on workers?
In any case, it seems to work and be clearer, at least to me.